### PR TITLE
Fixed convert to rc2 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asyncapi-editor",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "description": "Editor for AsyncAPI documentation.",
   "scripts": {
     "start": "node src/server/index.js"
@@ -13,8 +13,8 @@
   "dependencies": {
     "@moebius/http-graceful-shutdown": "^1.1.0",
     "archiver": "^3.0.0",
-    "asyncapi-converter": "^0.3.2",
-    "asyncapi-generator": "^0.25.1",
+    "asyncapi-converter": "^0.4.2",
+    "asyncapi-generator": "^0.27.0",
     "asyncapi-parser": "^0.12.2",
     "body-parser": "^1.17.2",
     "express": "^4.16.4",

--- a/src/server/routes/convert.js
+++ b/src/server/routes/convert.js
@@ -6,7 +6,7 @@ module.exports = router;
 
 router.post('/', async (req, res) => {
   try {
-    res.send(convert(req.body, '2.0.0-rc2'));
+    res.send(convert(req.body, '2.0.0'));
   } catch (e) {
     return res.status(422).send({
       code: 'convert-error',

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -5,8 +5,8 @@
 
   <div id="convert-dialog" class="hidden">
     <img src="/img/rocket-launch.png">
-    <h2>Convert to 2.0.0-rc2</h2>
-    <p>Your document is using an old version of AsyncAPI. The playground only supports 2.0.0-rc2 and above. Convert your
+    <h2>Convert to 2.0.0</h2>
+    <p>Your document is using an old version of AsyncAPI. The playground only supports 2.0.0 and above. Convert your
       document to continue.</p>
     <div>
       {{>button button=true class="js-convert" style="margin-left:0;color:white;font-size:16px;padding:10px 15px;font-weight:normal;" text='Convert now' primary=true}}


### PR DESCRIPTION
Right now the playground is falling in some kind of loop when trying to convert old documents.
Seems that it was related to (now deprecated) asyncapi v2.0.0-rc2. 
The fix is to bump up dependencies and adjusting code to reflect that the conversion should happen between old versions and v2.

Not sure if next playground should be 1.3.7 or 1.4.0 though...