### PR TITLE
Add support in playground for relative $refs in api definition

### DIFF
--- a/src/server/middlewares/version.js
+++ b/src/server/middlewares/version.js
@@ -23,6 +23,7 @@ module.exports = async (req, res, next) => {
 
     try {
       doc = await AsyncAPIParser.parse(req.body, {
+        path: req.header('AsyncAPI.baseUrl'),
         resolve: {
           file: false,
         },

--- a/src/server/middlewares/version.js
+++ b/src/server/middlewares/version.js
@@ -23,7 +23,7 @@ module.exports = async (req, res, next) => {
 
     try {
       doc = await AsyncAPIParser.parse(req.body, {
-        path: req.header('AsyncAPI.baseUrl'),
+        path: req.header('x-asyncapi-base-url'),
         resolve: {
           file: false,
         },

--- a/src/server/routes/html.js
+++ b/src/server/routes/html.js
@@ -13,7 +13,7 @@ router.post('/generate', version, async (req, res) => {
       entrypoint: 'index.html',
       output: 'string',
     });
-    const html = await generator.generateFromString(req.body, req.header('AsyncAPI.baseUrl') || null);
+    const html = await generator.generateFromString(req.body, req.header('x-asyncapi-base-url') || null);
 
     res.send(html);
   } catch (e) {

--- a/src/server/routes/html.js
+++ b/src/server/routes/html.js
@@ -13,7 +13,7 @@ router.post('/generate', version, async (req, res) => {
       entrypoint: 'index.html',
       output: 'string',
     });
-    const html = await generator.generateFromString(req.body);
+    const html = await generator.generateFromString(req.body, req.header('AsyncAPI.baseUrl') || null);
 
     res.send(html);
   } catch (e) {

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -59,6 +59,7 @@
         .send(state.code)
         .set('Accept', 'text/plain')
         .set('Content-Type', 'text/plain')
+        .set('AsyncAPI.baseUrl', state.url)
         .end((err, res) => {
           if (err) {
             if (res.body && res.body.code === 'old-version') {
@@ -116,6 +117,7 @@
     App.addEventListener('onCodeChange', (e) => {
       if (String(e.detail).trim().length) {
         state.code = e.detail;
+        state.url = document.getElementById('fetch-document-url').value;
         generate();
       }
     });

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -50,6 +50,7 @@
 
     const state = {
       code: null,
+      url: null,
       template: 'html',
     };
 
@@ -98,6 +99,7 @@
 
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('load')) {
+      document.getElementById('fetch-document-url').value = urlParams.get('load'); 
       fetch(urlParams.get('load'))
         .then(function (response) {
           if (!response.ok) throw new Error(response.statusText);

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -60,7 +60,7 @@
         .send(state.code)
         .set('Accept', 'text/plain')
         .set('Content-Type', 'text/plain')
-        .set('AsyncAPI.baseUrl', state.url)
+        .set('x-asyncapi-base-url', state.url)
         .end((err, res) => {
           if (err) {
             if (res.body && res.body.code === 'old-version') {


### PR DESCRIPTION
Playground does not support relative urls in $refs

Solution:
When loading code from url:
  it sends the api definition url as http header
  json-ref-parser will use then use this value as base file for dereferencing
Also, when loading from url param, input field is filled up for later use.

It was tested with this api definition:
https://raw.githubusercontent.com/ivangsa/playground/master/examples/multiple-files/asyncapi.yml