### PR TITLE
Support defining default URL with env. variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and
 npm start
 ```
 
-and go to [http://localhost:5000]().
+and go to [http://localhost:5000](http://localhost:5000).
 
 ## Build docker image
 
@@ -30,5 +30,33 @@ docker build -t asyncapi-playground .
 docker run -d --name asyncapi-playground -p 83:5000 asyncapi-playground:latest
 ```
 
-Then browse to [http://localhost:83/]()
+Then browse to [http://localhost:83](http://localhost:83)
 
+## Preloading
+
+There are two options to open a specific asyncapi spec:
+
+#### 1. `load` query parameter
+
+Open the playground with the `load` query parameter set to the URL the app should load on start.
+
+Example:
+
+```
+http://localhost:5000/?load=http://my.doma.in/spec.yaml
+```
+
+
+#### 2. `DEFAULT_SPEC_URL` environment variable
+
+Set the environment variable `DEFAULT_SPEC_URL` either before running `npm start` in command line or as a docker environment variable. The spec available on the given URL will be loaded when the app is opened.
+
+Example:
+
+```sh
+# with npm in CLI
+DEFAULT_SPEC_URL=http://my.doma.in/spec.yaml npm start
+
+# with docker
+docker run -d --name asyncapi-playground -p 83:5000 --env DEFAULT_SPEC_URL=http://my.doma.in/spec.yaml asyncapi-playground:latest
+```

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -37,6 +37,7 @@ app.get('/', (req, res) => {
     ...config.views,
     ...{
       embedded: !!req.query.embed,
+      defaultURL: process.env.DEFAULT_SPEC_URL
     }
   });
 });

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -97,10 +97,9 @@
         });
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('load')) {
-      document.getElementById('fetch-document-url').value = urlParams.get('load'); 
-      fetch(urlParams.get('load'))
+    function preloadURL(url) {
+      document.getElementById('fetch-document-url').value = url;
+      fetch(url)
         .then(function (response) {
           if (!response.ok) throw new Error(response.statusText);
           return response.text();
@@ -109,6 +108,16 @@
           App.dispatchEvent(new CustomEvent('updateCode', { detail: doc }));
         })
         .catch(console.error);
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('load')) {
+      preloadURL(url);
+    } else {
+      const defaultURL = "{{ defaultURL }}";
+      if (defaultURL) {
+        preloadURL(defaultURL);
+      }
     }
 
     App.addEventListener('templateChange', (e) => {


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The default URL can be loaded when the app opens by defining
`DEFAULT_SPEC_URL` environment variable.

**Related issue(s)**

Resolves asyncapi/playground#23
