### PR TITLE
feat: load AsyncAPI from **url** query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Then browse to [http://localhost:83/]()
 
 2 ways to load async apis from an url: 
 
-- Use the *load* parameter.
+- **load** parameter.
 
 ```
 https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```
 
-- Use the *url* parameter.
+- **url** parameter.
 ```
 https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then browse to [http://localhost:83/]()
 
 ## Load async api
 
-2 ways to load async apis from an url: 
+There are two parameters that serve the same purpose:
 
 - **load** parameter:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Then browse to [http://localhost:83/]()
 There are two parameters that serve the same purpose:
 
 - **load** parameter:
-
 ```
 https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Then browse to [http://localhost:83/]()
 
 2 ways to load async apis from an url: 
 
-- **load** parameter.
+- **load** parameter:
 
 ```
 https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```
 
-- **url** parameter.
+- **url** parameter:
 ```
 https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,18 @@ docker run -d --name asyncapi-playground -p 83:5000 asyncapi-playground:latest
 
 Then browse to [http://localhost:83/]()
 
+## Load async api
+
+2 ways to load async apis from an url: 
+
+- Use the *load* parameter.
+
+```
+https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
+```
+
+- Use the *url* parameter.
+```
+https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
+```
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run -d --name asyncapi-playground -p 83:5000 asyncapi-playground:latest
 
 Then browse to [http://localhost:83/]()
 
-## Load async api
+## Load AsyncAPI with URL query parameter
 
 There are two parameters that serve the same purpose:
 
@@ -45,4 +45,3 @@ https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/asyncapi/
 ```
 https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```
-

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -109,10 +109,6 @@
         .catch(console.error);
     }
 
-    function updateFetchDocumentUrlElement(value) {
-      document.getElementById('fetch-document-url').value = value;
-    }
-
     const urlParams = new URLSearchParams(window.location.search);
     const asyncApiUrl = urlParams.get('load') || urlParams.get('url');
 

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -97,10 +97,8 @@
         });
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('load')) {
-      document.getElementById('fetch-document-url').value = urlParams.get('load'); 
-      fetch(urlParams.get('load'))
+    function loadAsyncApi(asyncApiUrl) {
+      fetch(asyncApiUrl)
         .then(function (response) {
           if (!response.ok) throw new Error(response.statusText);
           return response.text();
@@ -109,6 +107,26 @@
           App.dispatchEvent(new CustomEvent('updateCode', { detail: doc }));
         })
         .catch(console.error);
+    }
+
+    function updateFetchDocumentUrlElement(value) {
+      document.getElementById('fetch-document-url').value = value;
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+
+    if (urlParams.get('load')) {
+      const asyncApiUrl = urlParams.get('load')
+
+      updateFetchDocumentUrlElement(asyncApiUrl)
+      loadAsyncApi(asyncApiUrl)
+    }
+
+    if (urlParams.get('url')) {
+      const asyncApiUrl = urlParams.get('url')
+
+      updateFetchDocumentUrlElement(asyncApiUrl)
+      loadAsyncApi(asyncApiUrl)
     }
 
     App.addEventListener('templateChange', (e) => {

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -114,19 +114,11 @@
     }
 
     const urlParams = new URLSearchParams(window.location.search);
+    const asyncApiUrl = urlParams.get('load') || urlParams.get('url');
 
-    if (urlParams.get('load')) {
-      const asyncApiUrl = urlParams.get('load')
-
-      updateFetchDocumentUrlElement(asyncApiUrl)
-      loadAsyncApi(asyncApiUrl)
-    }
-
-    if (urlParams.get('url')) {
-      const asyncApiUrl = urlParams.get('url')
-
-      updateFetchDocumentUrlElement(asyncApiUrl)
-      loadAsyncApi(asyncApiUrl)
+    if (asyncApiUrl) {
+      document.getElementById('fetch-document-url').value = asyncApiUrl;
+      loadAsyncApi(asyncApiUrl);
     }
 
     App.addEventListener('templateChange', (e) => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Allow to load async api from 'url' parameter. The behavior is similar to the 'load' parameter.
- Update readme to document use of 'load' and 'url' paramters.



**Related issue(s)**

Resolves #26 