### PR TITLE
feat: log server url on startup

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -56,7 +56,17 @@ app.use((err, req, res, next) => {
   res.status(500).send(error);
 });
 
-const server = app.listen(process.env.PORT || config.api.port);
+const getReadableAddress = (address) => {
+  if (address === '::') return 'localhost'
+
+  return address
+}
+
+const server = app.listen(process.env.PORT || config.api.port, () => {
+  const { port, address } = server.address()
+
+  console.log(`Application available on http://${getReadableAddress(address)}:${port}`)
+});
 const shutdownManager = new GracefulShutdownManager(server);
 
 process.on('SIGTERM', () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Log the server url on startup

By default when ipv6 is available, the server object of express will give '::' as the server address. I took the initiative to print it as 'localhost' to make it more readable but that's only a proposal 😄 

**Related issue(s)**
No issue yet, but the subject was mentioned [here](https://github.com/asyncapi/playground/pull/37)