### PR TITLE
ci: Update docker image to use lighter debian image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-buster-slim
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
See comments in #25

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As suggested in #25, the base for the docker image was changed from node:12 to node:12-buster-slim. This divides the image size by ~4. Only change is the base, as there are no distrib-specific commands (like package installations)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

See also #25 