### PR TITLE
feat: show exact errors when a parser fails

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -51,7 +51,12 @@ app.use((err, req, res, next) => {
     code: err.code || 'unexpected',
     message: err.message || 'Unexpected error',
   };
-  if (err.errors) error.errors = err.errors;
+  if (err.detail && err.detail.startsWith("bad indentation")) {
+    error.code = 'bad indentation';
+    error.message = err.detail;
+  }
+  if (err.validationErrors) error.validationErrors = err.validationErrors;
+
 
   res.status(500).send(error);
 });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -51,13 +51,8 @@ app.use((err, req, res, next) => {
     code: err.code || 'unexpected',
     message: err.message || 'Unexpected error',
   };
-  if (err.detail && err.detail.startsWith("bad indentation")) {
-    error.code = 'bad indentation';
-    error.message = err.detail;
-  }
+  if (err.detail) error.detail = err.detail;
   if (err.validationErrors) error.validationErrors = err.validationErrors;
-
-
   res.status(500).send(error);
 });
 

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -69,7 +69,21 @@
             } else {
               const errorsEl = document.getElementById('document-errors');
               const errorWrapperEl = document.querySelector('.errors-wrapper');
-              errorsEl.innerHTML = res.body.errors ? JSON.stringify(res.body.errors, null, 2) : res.body.message;
+
+              function getErrorsHTMLFrom(res) {
+                if (res.body.detail && res.body.code === 'bad indentation') {
+                  return res.body.detail;
+                }
+
+                if (res.body.validationErrors) {
+                  const errorsSimplified = res.body.validationErrors.map(error => `${error.title} on line ${error.location.startLine}, column ${error.location.startColumn}`);
+                  return JSON.stringify(errorsSimplified, null, 2);
+                }
+
+                return res.body.message;
+              }
+
+              errorsEl.innerHTML = getErrorsHTMLFrom(res);
               errorWrapperEl.classList.remove('errors-wrapper--old-version');
               errorWrapperEl.classList.remove('errors-wrapper--hidden');
             }

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -71,12 +71,19 @@
               const errorWrapperEl = document.querySelector('.errors-wrapper');
 
               function getErrorsHTMLFrom(res) {
+                function getErrorMessage(error) {
+                  if (error.location.startLine && error.location.startColumn) {
+                    return `${error.title} at line ${error.location.startLine}, column ${error.location.startColumn}`
+                  }
+                  return `${error.title}`;
+                }
+
                 if (res.body.detail) {
                   return res.body.detail;
                 }
 
                 if (res.body.validationErrors) {
-                  const errorsSimplified = res.body.validationErrors.map(error => `${error.title} on line ${error.location.startLine}, column ${error.location.startColumn}`);
+                  const errorsSimplified = res.body.validationErrors.map(getErrorMessage);
                   return JSON.stringify(errorsSimplified, null, 2);
                 }
 

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -71,7 +71,7 @@
               const errorWrapperEl = document.querySelector('.errors-wrapper');
 
               function getErrorsHTMLFrom(res) {
-                if (res.body.detail && res.body.code === 'bad indentation') {
+                if (res.body.detail) {
                   return res.body.detail;
                 }
 


### PR DESCRIPTION
**Description**
This change is because when the parser fails before generating the html view. If the parser fails, it only shows that an error ocurred but it doen't show the errors details or where are they located.
![image](https://user-images.githubusercontent.com/14940638/105390882-7316b700-5c11-11eb-9173-214eb1f240eb.png)

With this change, I try to show those errors on the error view so the user would know where the file is failing. 
![image](https://user-images.githubusercontent.com/14940638/105391134-b53ff880-5c11-11eb-82b2-99b972ef6cdb.png)

Also, I've detected that there are errors that are diferent and do not come on `validationErrors`, but it comes with a `detail` field so I also include a way to manage it and show it through this view.

![image](https://user-images.githubusercontent.com/14940638/105391367-f6d0a380-5c11-11eb-808b-1bb16d04f9e9.png)

I've been working these days with this tool, and I think that this is the only key part that I've missed. I think that this was implemented times ago through `errors` field when the parsed fails, but probably it changed and nobody changed this.

Resolves: #62
