### PR TITLE
fix: markdown template rendering and download

### DIFF
--- a/src/server/routes/markdown.js
+++ b/src/server/routes/markdown.js
@@ -23,13 +23,13 @@ router.post('/generate', version, async (req, res) => {
     };
 
     const generator = new AsyncAPIGenerator('@asyncapi/markdown-template', os.tmpdir(), {
-      entrypoint: 'asyncapi.md',
+      entrypoint: 'asyncapi.js',
       output: 'string',
       forceWrite: true,
     });
     const markdown = await generator.generateFromString(req.body, parserOptions);
 
-    res.send(markdown);
+    res.send(markdown.content);
   } catch (e) {
     return res.status(422).send({
       code: 'incorrect-format',
@@ -47,12 +47,12 @@ router.post('/download', async (req, res, next) => {
   archive.append(req.body.data, { name: 'asyncapi.yml' });
   try {
     const generator = new AsyncAPIGenerator('@asyncapi/markdown-template', os.tmpdir(), {
-      entrypoint: 'asyncapi.md',
+      entrypoint: 'asyncapi.js',
       output: 'string',
       forceWrite: true,
     });
     const markdown = await generator.generateFromString(req.body.data);
-    archive.append(markdown, { name: 'asyncapi.md' });
+    archive.append(markdown.content, { name: 'asyncapi.md' });
     archive.finalize();
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- After migration in markdown template from Nunjucks to React is stopped working in the playground (after upgrade of course). The reason is that when generating a template with entrypoint using `generateFromString` you are not getting the generation content but an object with content and metadata like:
```
{
   "content":"# Account Service 1.0.0 documentation\n\nThis service is in charge of processing user signups\n## Table of Contents\n\n* [Channels](#channels)\n\n## Channels\n\n### **user/signedup** Channel\n\n#### `subscribe` Operation\n\n##### Message\n\n###### Payload\n\n| Name | Type | Description | Accepted values |\n|-|-|-|-|\n| displayName | string | Name of the user | _Any_ |\n| email | string | Email of the user | _Any_ |\n| request | string | Encrypted data | _Any_ |\n\n###### Examples of payload _(generated)_\n\n```json\n{\n  \"displayName\": \"string\",\n  \"email\": \"user@example.com\",\n  \"request\": \"string\"\n}\n```\n\n\n\n\n",
   "metadata":{
      "fileName":"asyncapi.md"
   }
}
```