### PR TITLE
feat: increase limit of the spec size that can be processed

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,7 +10,7 @@ const htmlRoute = require('./routes/html');
 const markdownRoute = require('./routes/markdown');
 const convertRoute = require('./routes/convert');
 
-app.use(bodyParser.text({ type: 'text/plain' }));
+app.use(bodyParser.text({ type: 'text/plain', limit: '5mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static(path.resolve(__dirname, '../../public')));
 app.set('views', path.join(__dirname, 'views'));


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- increase limit from default 100kb to 5mb to fix rendering of specs like https://playground.asyncapi.io/?url=https://bitbucket.org/qbmt/zbos-mqtt-api/raw/25ee18cee0db90d9f370e0bcf1bfbb6fbb7621ce/zbos_mqtt-all-asyncapi.json