### PR TITLE
feat: add readOnly and template query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,28 @@ docker run -d --name asyncapi-playground -p 83:5000 asyncapi-playground:latest
 
 Then browse to [http://localhost:83/]()
 
-## Load AsyncAPI with URL query parameter
+## URL query parameters:
 
-There are two parameters that serve the same purpose:
+- **load** - load the external AsyncAPI spec:
 
-- **load** parameter:
 ```
 https://playground.asyncapi.io/?load=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
 ```
 
-- **url** parameter:
+- **url** - this same purpose as **load**:
+
 ```
 https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml
+```
+
+- **template** - show given template. Allowed values are `markdown` and `html`:
+
+```
+https://playground.asyncapi.io/?template=markdown
+```
+
+- **collapseEditor** - collapse the editor. Allowed values are `true` and empty string:
+
+```
+https://playground.asyncapi.io/?collapseEditor
 ```

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/asyncapi/a
 https://playground.asyncapi.io/?template=markdown
 ```
 
-- **collapseEditor** - collapse the editor. Allowed values are `true` and empty string:
+- **readOnly** - show only rendered template. Allowed values are `true` and empty string:
 
 ```
-https://playground.asyncapi.io/?collapseEditor
+https://playground.asyncapi.io/?readOnly
 ```

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -190,6 +190,7 @@
     // Show app after updating above styles
     // thanks to this we avoid the appearance of the editor and topbar for a few milliseconds.
     document.querySelector('#App').classList.remove('hidden');
+    document.querySelector('.CodeMirror').CodeMirror.refresh();
 
     if (asyncApiUrl) {
       document.getElementById('fetch-document-url').value = asyncApiUrl;

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -1,4 +1,4 @@
-<div id="App">
+<div id="App" class="hidden">
   {{> topbar embedded=embedded }}
   {{~> left-pane app='#App' ~}}
   {{> right-pane app='#App' }}
@@ -41,6 +41,9 @@
 </div>
 
 <style>
+.hidden {
+  display: none;
+}
 .convert-dialog {
   position: fixed;
   left: calc(50% - 240px);
@@ -82,6 +85,8 @@
 
     const urlParams = new URLSearchParams(window.location.search);
     const templateParam = urlParams.get('template');
+    const readOnlyParam = urlParams.get('readOnly');
+    const asyncApiUrl = urlParams.get('load') || urlParams.get('url');
 
     const state = {
       code: null,
@@ -174,7 +179,18 @@
         .catch(console.error);
     }
 
-    const asyncApiUrl = urlParams.get('load') || urlParams.get('url');
+    // If someone pass the `readOnly` query parameter then hide left pane with topbar
+    if (readOnlyParam === '' || readOnlyParam === 'true') {
+      document.querySelector('.{{css.topBar}}').classList.add('hidden');
+      document.querySelector('.{{css.leftPane}}').classList.add('{{css.leftPane}}--collapsed');
+      document.querySelector('.{{css.leftPane}}__collapser').classList.add('hidden');
+      document.querySelector('.{{css.rightPane}}').style.top = 0;
+      document.querySelector('.{{css.rightPane}}__toolbar').classList.add('hidden');
+    }
+    // Show app after updating above styles
+    // thanks to this we avoid the appearance of the editor and topbar for a few milliseconds.
+    document.querySelector('#App').classList.remove('hidden');
+
     if (asyncApiUrl) {
       document.getElementById('fetch-document-url').value = asyncApiUrl;
       loadAsyncApi(asyncApiUrl);

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -80,10 +80,13 @@
   window.addEventListener('load', () => {
     const App = document.getElementById('App');
 
+    const urlParams = new URLSearchParams(window.location.search);
+    const templateParam = urlParams.get('template');
+
     const state = {
       code: null,
       url: null,
-      template: 'html',
+      template: templateParam === 'markdown' ? 'markdown' : 'html',
     };
 
     const ONE_DAY = 24 * 60 * 60 * 1000; /* ms */
@@ -171,15 +174,14 @@
         .catch(console.error);
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
     const asyncApiUrl = urlParams.get('load') || urlParams.get('url');
-
     if (asyncApiUrl) {
       document.getElementById('fetch-document-url').value = asyncApiUrl;
       loadAsyncApi(asyncApiUrl);
     }
 
     App.addEventListener('templateChange', (e) => {
+      console.log('dupa')
       state.template = e.detail;
       generate();
     });

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -189,6 +189,7 @@
     }
     // Show app after updating above styles
     // thanks to this we avoid the appearance of the editor and topbar for a few milliseconds.
+    // We have to also refresh the CodeMirror container
     document.querySelector('#App').classList.remove('hidden');
     document.querySelector('.CodeMirror').CodeMirror.refresh();
 

--- a/src/server/views/app.handlebars
+++ b/src/server/views/app.handlebars
@@ -181,7 +181,6 @@
     }
 
     App.addEventListener('templateChange', (e) => {
-      console.log('dupa')
       state.template = e.detail;
       generate();
     });

--- a/src/server/views/partials/left-pane.handlebars
+++ b/src/server/views/partials/left-pane.handlebars
@@ -301,6 +301,13 @@ components:
   const FetchInput = document.getElementById('fetch-document-url');
   const FetchForm = document.getElementById('fetch-document');
 
+  const urlParams = new URLSearchParams(window.location.search);
+  const collapseEditorParam = urlParams.get('collapseEditor');
+  
+  if (collapseEditorParam === '' || collapseEditorParam === 'true') {
+    document.querySelector('.{{css.leftPane}}').classList.add('{{css.leftPane}}--collapsed');
+  }
+
   document.querySelector('.js-collapse-{{css.leftPane}}').addEventListener('click', function () {
     document.querySelector('.{{css.leftPane}}').classList.toggle('{{css.leftPane}}--collapsed');
   });

--- a/src/server/views/partials/left-pane.handlebars
+++ b/src/server/views/partials/left-pane.handlebars
@@ -301,13 +301,6 @@ components:
   const FetchInput = document.getElementById('fetch-document-url');
   const FetchForm = document.getElementById('fetch-document');
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const collapseEditorParam = urlParams.get('collapseEditor');
-  
-  if (collapseEditorParam === '' || collapseEditorParam === 'true') {
-    document.querySelector('.{{css.leftPane}}').classList.add('{{css.leftPane}}--collapsed');
-  }
-
   document.querySelector('.js-collapse-{{css.leftPane}}').addEventListener('click', function () {
     document.querySelector('.{{css.leftPane}}').classList.toggle('{{css.leftPane}}--collapsed');
   });

--- a/src/server/views/partials/right-pane.handlebars
+++ b/src/server/views/partials/right-pane.handlebars
@@ -85,13 +85,10 @@
 <script>
 (() => {
   const App = document.querySelector('{{app}}');
-  const state = {
-    template: 'html',
-  };
+  const templateTabs = document.getElementById('TemplateTabs');
 
-  document.getElementById('TemplateTabs').addEventListener('selectTab', (e) => {
-    var iframe = document.getElementById('result');
-
+  templateTabs.addEventListener('selectTab', (e) => {
+    const iframe = document.getElementById('result');
     iframe.onload = () => { // Use onload instead of addEventListener to listen the event just once.
       App.dispatchEvent(new CustomEvent('templateChange', { detail: e.detail }));
     };
@@ -109,5 +106,18 @@
   document.querySelector('.js-download-docs').addEventListener('click', function () {
     App.dispatchEvent(new CustomEvent('downloadDocs'));
   });
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const templateParam = urlParams.get('template');
+  
+  switch (templateParam) {
+    case 'markdown': {
+      const markdownTab = templateTabs.querySelector('input[value="markdown"]');
+      markdownTab.checked = true;
+      templateTabs.dispatchEvent(new CustomEvent('selectTab', { detail: 'markdown' }));
+      break;
+    }
+    // html is opened by default
+  }
 })();
 </script>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add two query parameters:
- `readOnly` which will hide the editor and topbar. Allowed values: empty or `true`
- `template` which will open the given template. Allowed values: `markdown` and `html`

Query like `?readOnly&template=markdown` will collapse the editor, the topbar and open the rendered markdown template. By default editor with topbar will be displayed and rendered will be html (as currently).

**Related issue(s)**
Resolves https://github.com/asyncapi/playground/issues/138