### PR TITLE
Update asyncapi generator to version 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^1.0.0",
         "@asyncapi/converter": "^0.7.0",
-        "@asyncapi/generator": "^1.8.25",
+        "@asyncapi/generator": "^1.9.0",
         "@asyncapi/html-template": "^0.24.8",
         "@asyncapi/markdown-template": "^1.0.0",
         "@asyncapi/parser": "^1.14.1",
@@ -77,14 +77,14 @@
       }
     },
     "node_modules/@asyncapi/generator": {
-      "version": "1.8.25",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.8.25.tgz",
-      "integrity": "sha512-4RWszFQdDXELjQY/MrtVd6Ie1tc3rGkRxmgdpUt7K9Z6SssqyqM7JFEuJ5cijOvzkLceXdfxgcWCKMesjH03FQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.9.0.tgz",
+      "integrity": "sha512-DpJtdTn4m2fx/qQDMo+oTywR7P/ui3i6OQii9ieCNR35/C5fMY/BgvJfnxmX1joFsUx5EizDMF7FrDjNGXVRmA==",
       "dependencies": {
-        "@asyncapi/avro-schema-parser": "^0.6.0",
-        "@asyncapi/generator-react-sdk": "^0.2.22",
+        "@asyncapi/avro-schema-parser": "^1.0.0",
+        "@asyncapi/generator-react-sdk": "^0.2.23",
         "@asyncapi/openapi-schema-parser": "^2.0.1",
-        "@asyncapi/parser": "^1.12.0",
+        "@asyncapi/parser": "^1.14.0",
         "@asyncapi/raml-dt-schema-parser": "^2.0.1",
         "@npmcli/arborist": "^2.2.4",
         "ajv": "^6.10.2",
@@ -97,7 +97,7 @@
         "js-yaml": "^3.13.1",
         "levenshtein-edit-distance": "^2.0.5",
         "loglevel": "^1.6.8",
-        "markdown-it": "^8.4.1",
+        "markdown-it": "^12.3.2",
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
         "nunjucks": "^3.2.0",
@@ -172,11 +172,6 @@
         "rollup": "^2.60.1",
         "source-map-support": "^0.5.19"
       }
-    },
-    "node_modules/@asyncapi/generator/node_modules/@asyncapi/avro-schema-parser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.6.0.tgz",
-      "integrity": "sha512-zkCEudMfhdDuiqnuTii4jC365C7AQCD8AZ/CCHh3wB/s8UNkl8ydDA1KcDE35F5/s0mUFg0Z9VMxBX4rbLBdUA=="
     },
     "node_modules/@asyncapi/generator/node_modules/commander": {
       "version": "6.2.1",
@@ -3391,9 +3386,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -4827,18 +4825,31 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/markdown-it/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/marked": {
@@ -7163,14 +7174,14 @@
       }
     },
     "@asyncapi/generator": {
-      "version": "1.8.25",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.8.25.tgz",
-      "integrity": "sha512-4RWszFQdDXELjQY/MrtVd6Ie1tc3rGkRxmgdpUt7K9Z6SssqyqM7JFEuJ5cijOvzkLceXdfxgcWCKMesjH03FQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.9.0.tgz",
+      "integrity": "sha512-DpJtdTn4m2fx/qQDMo+oTywR7P/ui3i6OQii9ieCNR35/C5fMY/BgvJfnxmX1joFsUx5EizDMF7FrDjNGXVRmA==",
       "requires": {
-        "@asyncapi/avro-schema-parser": "^0.6.0",
-        "@asyncapi/generator-react-sdk": "^0.2.22",
+        "@asyncapi/avro-schema-parser": "^1.0.0",
+        "@asyncapi/generator-react-sdk": "^0.2.23",
         "@asyncapi/openapi-schema-parser": "^2.0.1",
-        "@asyncapi/parser": "^1.12.0",
+        "@asyncapi/parser": "^1.14.0",
         "@asyncapi/raml-dt-schema-parser": "^2.0.1",
         "@npmcli/arborist": "^2.2.4",
         "ajv": "^6.10.2",
@@ -7183,7 +7194,7 @@
         "js-yaml": "^3.13.1",
         "levenshtein-edit-distance": "^2.0.5",
         "loglevel": "^1.6.8",
-        "markdown-it": "^8.4.1",
+        "markdown-it": "^12.3.2",
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
         "nunjucks": "^3.2.0",
@@ -7196,11 +7207,6 @@
         "typescript": "^4.2.2"
       },
       "dependencies": {
-        "@asyncapi/avro-schema-parser": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.6.0.tgz",
-          "integrity": "sha512-zkCEudMfhdDuiqnuTii4jC365C7AQCD8AZ/CCHh3wB/s8UNkl8ydDA1KcDE35F5/s0mUFg0Z9VMxBX4rbLBdUA=="
-        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -9631,9 +9637,9 @@
       }
     },
     "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "env-paths": {
       "version": "2.2.1",
@@ -10750,15 +10756,30 @@
       }
     },
     "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "linkify-it": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+          "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        }
       }
     },
     "marked": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^1.0.0",
     "@asyncapi/converter": "^0.7.0",
-    "@asyncapi/generator": "^1.8.25",
+    "@asyncapi/generator": "^1.9.0",
     "@asyncapi/html-template": "^0.24.8",
     "@asyncapi/markdown-template": "^1.0.0",
     "@asyncapi/parser": "^1.14.1",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Dependency asyncapi/generator version 1.8.25 caused an issue on startup. At least version 1.8.27 needed.
- Update executed to version 1.9.0
- Build app locally and tested via npm start and docker container: AsyncAPI Playground was started and AsyncAPI was shown without problems

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->